### PR TITLE
Replace cvcuda -> torchvision

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Supported use cases:
 
 The CUDA accelerated nodes can be used in real-time workflows for live video streams using [comfystream](https://github.com/yondonfu/comfystream).
 
-At the moment, these nodes can only be used on Linux because the underlying CUDA acceleration library only supports Linux ([refer to this issue](https://github.com/CVCUDA/CV-CUDA/issues/92) for tracking of Windows support).
-
 --- 
 
 - [ComfyUI-Background-Edit](#comfyui-background-edit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,9 @@
 [project]
 name = "comfyui-background-edit"
 description = "ComfyUI nodes for editing background of images/videos with CUDA acceleration support."
-version = "1.0.0"
+version = "1.1.0"
 license = { file = "LICENSE" }
-dependencies = [
-  "torch",
-  "torchvision"
-]
+dependencies = ["torch", "torchvision"]
 
 [project.urls]
 Repository = "https://github.com/yondonfu/ComfyUI-Background-Edit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,8 @@ description = "ComfyUI nodes for editing background of images/videos with CUDA a
 version = "1.0.0"
 license = { file = "LICENSE" }
 dependencies = [
-  "opencv-python",
-  "numpy",
   "torch",
-  "https://github.com/CVCUDA/CV-CUDA/releases/download/v0.12.0-beta/cvcuda_cu12-0.12.0b0-cp311-cp311-linux_x86_64.whl",
+  "torchvision"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-opencv-python
-numpy
 torch
-https://github.com/CVCUDA/CV-CUDA/releases/download/v0.12.0-beta/cvcuda_cu12-0.12.0b0-cp311-cp311-linux_x86_64.whl
+torchvision


### PR DESCRIPTION
Replace usage of CVCUDA with torchvision to support Windows.

From a brief test it looks like:

- CVCUDA gaussian blur is faster than torchvision, but the latter should still be fast enough for real-time processing
- torchvision compositing should be just as fast if not faster than CVCUDA and we don't need to deal with converting between torch.Tensor and cvcuda.Tensor