### PR TITLE
positive/odd enforcement

### DIFF
--- a/nodes/gaussian_blur.py
+++ b/nodes/gaussian_blur.py
@@ -14,7 +14,7 @@ class GaussianBlur:
             "required": {
                 "images": ("IMAGE",),
                 "kernel_size": ("INT", {"default": 61, "min": 1, "step": 2}),
-                "sigma": ("INT", {"default": 5, "min": 1, "step": 2}),
+                "sigma": ("INT", {"default": 5, "min": 1, "step": 1}),
                 "mode": (["cuda", "cpu"], {"default": "cuda"}),
             }
         }

--- a/nodes/gaussian_blur.py
+++ b/nodes/gaussian_blur.py
@@ -13,8 +13,8 @@ class GaussianBlur:
         return {
             "required": {
                 "images": ("IMAGE",),
-                "kernel_size": ("INT", {"default": 61}),
-                "sigma": ("INT", {"default": 5}),
+                "kernel_size": ("INT", {"default": 61, "min": 1, "step": 2}),
+                "sigma": ("INT", {"default": 5, "min": 1, "step": 2}),
                 "mode": (["cuda", "cpu"], {"default": "cuda"}),
             }
         }


### PR DESCRIPTION
feat: Add input validation for Gaussian Blur parameters

Added step=2 and min=1 constraints to kernel_size and sigma parameters in the GaussianBlur node to ensure only valid odd numbers can be input.

Changes:
- kernel_size: Added step=2, min=1 to enforce odd numbers
- sigma: Added step=2, min=1 to enforce odd numbers